### PR TITLE
telegraf relay separated from queue/polling

### DIFF
--- a/terraform/telegraf/certificates.tf
+++ b/terraform/telegraf/certificates.tf
@@ -8,14 +8,14 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  zone_id = data.aws_route53_zone.relops_mozops_net.zone_id
+  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
 }

--- a/terraform/telegraf/datasources.tf
+++ b/terraform/telegraf/datasources.tf
@@ -1,6 +1,6 @@
 # Look up usw2 vpc
 data "aws_vpcs" "moz_internal_us_west_2" {
-  provider = "aws.us-west-2"
+  provider = aws.us-west-2
 
   tags = {
     Name = "moz-internal-us-west-2"

--- a/terraform/telegraf/ecs-cluster.tf
+++ b/terraform/telegraf/ecs-cluster.tf
@@ -1,12 +1,12 @@
 resource "aws_ecs_cluster" "main" {
   name = "telegraf"
 
-  tags = "${merge(
+  tags = merge(
     local.common_tags,
     map(
       "Name", "telegraf"
     )
-  )}"
+  )
 }
 
 resource "aws_security_group" "ecs_public_sg" {
@@ -22,17 +22,17 @@ resource "aws_security_group" "ecs_public_sg" {
   }
 
   ingress {
-    from_port       = "${var.app_port}"
-    to_port         = "${var.app_port}"
+    from_port       = var.relay_port
+    to_port         = var.relay_port
     protocol        = "tcp"
-    security_groups = ["${aws_security_group.lb_sg.id}"]
+    security_groups = [aws_security_group.lb_sg.id]
   }
 
   ingress {
-    from_port       = "${var.webhook_port}"
-    to_port         = "${var.webhook_port}"
+    from_port       = var.webhook_port
+    to_port         = var.webhook_port
     protocol        = "tcp"
-    security_groups = ["${aws_security_group.lb_sg.id}"]
+    security_groups = [aws_security_group.lb_sg.id]
   }
 
   egress {
@@ -44,7 +44,7 @@ resource "aws_security_group" "ecs_public_sg" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }
@@ -54,17 +54,17 @@ resource "aws_ecs_task_definition" "app" {
   family                   = "telegraf"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  execution_role_arn       = "${aws_iam_role.ecs-task-exec-role.arn}"
-  cpu                      = "${var.fargate_cpu}"
-  memory                   = "${var.fargate_memory}"
-  depends_on               = ["aws_iam_role.ecs-task-exec-role"] # force recreate on change sha in definition
+  execution_role_arn       = aws_iam_role.ecs-task-exec-role.arn
+  cpu                      = var.relay_cpu
+  memory                   = var.relay_memory
+  depends_on               = [aws_iam_role.ecs-task-exec-role] # force recreate on change sha in definition
 
   container_definitions = <<DEFINITION
 [
   {
-    "cpu": ${var.fargate_cpu},
-    "image": "${var.app_image}",
-    "memory": ${var.fargate_memory},
+    "cpu": ${var.relay_cpu},
+    "image": "${var.relay_image}",
+    "memory": ${var.relay_memory},
     "name": "telegraf",
     "environment" : [
       { "name" : "policy_sha1", "value" : "${sha1(file("ecs-task-exec-role.tf"))}" },
@@ -84,8 +84,8 @@ resource "aws_ecs_task_definition" "app" {
     "networkMode": "awsvpc",
     "portMappings": [
       {
-        "containerPort": ${var.app_port},
-        "hostPort": ${var.app_port}
+        "containerPort": ${var.relay_port},
+        "hostPort": ${var.relay_port}
       },
       {
         "containerPort": ${var.webhook_port},
@@ -107,22 +107,28 @@ DEFINITION
 
 resource "aws_ecs_service" "main" {
   name = "telegraf"
-  cluster = "${aws_ecs_cluster.main.id}"
-  task_definition = "${aws_ecs_task_definition.app.arn}"
-  desired_count = "${var.app_count}"
+  cluster = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count = var.relay_count
   launch_type = "FARGATE"
 
   network_configuration {
     subnets = data.aws_subnet_ids.public_subnets.ids
-    security_groups = ["${aws_security_group.ecs_public_sg.id}"]
+    security_groups = [aws_security_group.ecs_public_sg.id]
     assign_public_ip = true
   }
 
   load_balancer {
-    target_group_arn = "${aws_lb_target_group.lb_target_group.arn}"
+    target_group_arn = aws_lb_target_group.lb_target_group.arn
     container_name = "telegraf"
     container_port = 8086
   }
 
-  depends_on = ["aws_lb_listener.front_end", "aws_ecs_task_definition.app"]
+  load_balancer {
+    target_group_arn = aws_lb_target_group.lb_target_group2.arn
+    container_name = "telegraf"
+    container_port = 1619
+  }
+
+  depends_on = [aws_lb_listener.front_end, aws_ecs_task_definition.app]
 }

--- a/terraform/telegraf/ecs-queues.tf
+++ b/terraform/telegraf/ecs-queues.tf
@@ -1,0 +1,61 @@
+resource "aws_ecs_service" "main_queues" {
+  name = "telegraf_queues"
+  cluster = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app_queues.arn
+  desired_count = var.collection_count
+  launch_type = "FARGATE"
+
+  network_configuration {
+    subnets = data.aws_subnet_ids.public_subnets.ids
+    security_groups = [aws_security_group.ecs_public_sg.id]
+    assign_public_ip = true
+  }
+
+  depends_on = [aws_ecs_task_definition.app_queues]
+}
+
+resource "aws_ecs_task_definition" "app_queues" {
+  family                   = "telegraf"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.ecs-task-exec-role.arn
+  cpu                      = var.collection_cpu
+  memory                   = var.collection_memory
+  depends_on               = [aws_iam_role.ecs-task-exec-role] # force recreate on change sha in definition
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": ${var.collection_cpu},
+    "image": "${var.collection_image}",
+    "memory": ${var.collection_memory},
+    "name": "telegraf",
+    "environment" : [
+      { "name" : "policy_sha1", "value" : "${sha1(file("ecs-task-exec-role.tf"))}" },
+      { "name" : "INFLUXDB_URL", "value" : "${var.influxdb_url}" },
+      { "name" : "INFLUXDB_USER", "value" : "${var.influxdb_user}" },
+      { "name" : "INFLUXDB_DB", "value" : "${var.influxdb_db}" },
+      { "name" : "TELEGRAF_CONFIG", "value" : "telegraf_queues.conf" },
+      { "name" : "INTERVAL", "value" : "${var.interval}" },
+      { "name" : "MEDIUM_INTERVAL", "value" : "${var.medium_interval}" },
+      { "name" : "LONG_INTERVAL", "value" : "${var.long_interval}" }
+    ],
+    "secrets": [
+        {
+            "name": "INFLUXDB_PASSWORD",
+            "valueFrom": "arn:aws:ssm:us-west-2:961225894672:parameter/influxdb_wo_password"
+        }
+    ],
+    "networkMode": "awsvpc",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.telegraf.name}",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream-prefix": "telegraf_queues"
+      }
+    }
+  }
+]
+DEFINITION
+}

--- a/terraform/telegraf/ecs-task-exec-role.tf
+++ b/terraform/telegraf/ecs-task-exec-role.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "ecs-task-assume-role-policy" {
 
 resource "aws_iam_role" "ecs-task-exec-role" {
   name               = "telegraf-ecs-task-exec-role"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs-task-assume-role-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs-task-assume-role-policy.json
 }
 
 resource "aws_iam_policy" "secrets_read_policy" {
@@ -38,8 +38,8 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "attach_secrets_policy" {
-  role = "${aws_iam_role.ecs-task-exec-role.name}"
-  policy_arn = "${aws_iam_policy.secrets_read_policy.arn}"
+  role = aws_iam_role.ecs-task-exec-role.name
+  policy_arn = aws_iam_policy.secrets_read_policy.arn
 }
 
 resource "aws_iam_policy" "ecr_policy" {
@@ -68,6 +68,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "attach_ecr_policy" {
-  role       = "${aws_iam_role.ecs-task-exec-role.name}"
-  policy_arn = "${aws_iam_policy.ecr_policy.arn}"
+  role       = aws_iam_role.ecs-task-exec-role.name
+  policy_arn = aws_iam_policy.ecr_policy.arn
 }

--- a/terraform/telegraf/ecs-vcs.tf
+++ b/terraform/telegraf/ecs-vcs.tf
@@ -1,0 +1,61 @@
+resource "aws_ecs_service" "main_vcs" {
+  name = "telegraf_vcs"
+  cluster = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app_vcs.arn
+  desired_count = var.collection_count
+  launch_type = "FARGATE"
+
+  network_configuration {
+    subnets = data.aws_subnet_ids.public_subnets.ids
+    security_groups = [aws_security_group.ecs_public_sg.id]
+    assign_public_ip = true
+  }
+
+  depends_on = [aws_ecs_task_definition.app_vcs]
+}
+
+resource "aws_ecs_task_definition" "app_vcs" {
+  family                   = "telegraf"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.ecs-task-exec-role.arn
+  cpu                      = var.collection_cpu
+  memory                   = var.collection_memory
+  depends_on               = [aws_iam_role.ecs-task-exec-role] # force recreate on change sha in definition
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": ${var.collection_cpu},
+    "image": "${var.collection_image}",
+    "memory": ${var.collection_memory},
+    "name": "telegraf",
+    "environment" : [
+      { "name" : "policy_sha1", "value" : "${sha1(file("ecs-task-exec-role.tf"))}" },
+      { "name" : "INFLUXDB_URL", "value" : "${var.influxdb_url}" },
+      { "name" : "INFLUXDB_USER", "value" : "${var.influxdb_user}" },
+      { "name" : "INFLUXDB_DB", "value" : "${var.influxdb_db}" },
+      { "name" : "TELEGRAF_CONFIG", "value" : "telegraf_vcs.conf" },
+      { "name" : "INTERVAL", "value" : "${var.interval}" },
+      { "name" : "MEDIUM_INTERVAL", "value" : "${var.medium_interval}" },
+      { "name" : "LONG_INTERVAL", "value" : "${var.long_interval}" }
+    ],
+    "secrets": [
+        {
+            "name": "INFLUXDB_PASSWORD",
+            "valueFrom": "arn:aws:ssm:us-west-2:961225894672:parameter/influxdb_wo_password"
+        }
+    ],
+    "networkMode": "awsvpc",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.telegraf.name}",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream-prefix": "telegraf_vcs"
+      }
+    }
+  }
+]
+DEFINITION
+}

--- a/terraform/telegraf/ecs-workers.tf
+++ b/terraform/telegraf/ecs-workers.tf
@@ -1,0 +1,61 @@
+resource "aws_ecs_service" "main_workers" {
+  name = "telegraf_workers"
+  cluster = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app_workers.arn
+  desired_count = var.collection_count
+  launch_type = "FARGATE"
+
+  network_configuration {
+    subnets = data.aws_subnet_ids.public_subnets.ids
+    security_groups = [aws_security_group.ecs_public_sg.id]
+    assign_public_ip = true
+  }
+
+  depends_on = [aws_ecs_task_definition.app_workers]
+}
+
+resource "aws_ecs_task_definition" "app_workers" {
+  family                   = "telegraf"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.ecs-task-exec-role.arn
+  cpu                      = var.collection_cpu
+  memory                   = var.collection_memory
+  depends_on               = [aws_iam_role.ecs-task-exec-role] # force recreate on change sha in definition
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": ${var.collection_cpu},
+    "image": "${var.collection_image}",
+    "memory": ${var.collection_memory},
+    "name": "telegraf",
+    "environment" : [
+      { "name" : "policy_sha1", "value" : "${sha1(file("ecs-task-exec-role.tf"))}" },
+      { "name" : "INFLUXDB_URL", "value" : "${var.influxdb_url}" },
+      { "name" : "INFLUXDB_USER", "value" : "${var.influxdb_user}" },
+      { "name" : "INFLUXDB_DB", "value" : "${var.influxdb_db}" },
+      { "name" : "TELEGRAF_CONFIG", "value" : "telegraf_workers.conf" },
+      { "name" : "INTERVAL", "value" : "${var.interval}" },
+      { "name" : "MEDIUM_INTERVAL", "value" : "${var.medium_interval}" },
+      { "name" : "LONG_INTERVAL", "value" : "${var.long_interval}" }
+    ],
+    "secrets": [
+        {
+            "name": "INFLUXDB_PASSWORD",
+            "valueFrom": "arn:aws:ssm:us-west-2:961225894672:parameter/influxdb_wo_password"
+        }
+    ],
+    "networkMode": "awsvpc",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_cloudwatch_log_group.telegraf.name}",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream-prefix": "telegraf_workers"
+      }
+    }
+  }
+]
+DEFINITION
+}

--- a/terraform/telegraf/lb.tf
+++ b/terraform/telegraf/lb.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "lb" {
   name               = "telegraf-load-balancer"
   internal           = false
   load_balancer_type = "application"
-  security_groups    = ["${aws_security_group.lb_sg.id}"]
+  security_groups    = [aws_security_group.lb_sg.id]
   subnets            = data.aws_subnet_ids.public_subnets.ids
 
   enable_deletion_protection = false
@@ -28,8 +28,8 @@ resource "aws_security_group" "lb_sg" {
   }
 
   ingress {
-    from_port   = "${var.webhook_port}"
-    to_port     = "${var.webhook_port}"
+    from_port   = var.webhook_port
+    to_port     = var.webhook_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -43,7 +43,7 @@ resource "aws_security_group" "lb_sg" {
 
   tags = {
     Terraform   = "true"
-    Repo_url    = "${var.repo_url}"
+    Repo_url    = var.repo_url
     Environment = "Prod"
     Owner       = "relops@mozilla.com"
   }
@@ -51,14 +51,14 @@ resource "aws_security_group" "lb_sg" {
 
 resource "aws_lb_target_group" "lb_target_group" {
   name        = "telegraf-lb-tg"
-  port        = "${var.app_port}"
+  port        = var.relay_port
   protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = join(", ", data.aws_vpcs.moz_internal_us_west_2.ids)
 
   health_check {
     path                = "/ping"
-    port                = "${var.app_port}"
+    port                = var.relay_port
     healthy_threshold   = 3
     unhealthy_threshold = 3
     interval            = 60
@@ -68,46 +68,55 @@ resource "aws_lb_target_group" "lb_target_group" {
 
 resource "aws_lb_target_group" "lb_target_group2" {
   name        = "telegraf-lb-tg2"
-  port        = "${var.webhook_port}"
-  protocol    = "HTTPS"
+  port        = var.webhook_port
+  protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = join(", ", data.aws_vpcs.moz_internal_us_west_2.ids)
+
+  health_check {
+    path                = "/ping"
+    port                = var.webhook_port
+    healthy_threshold   = 10
+    unhealthy_threshold = 10
+    interval            = 300
+    matcher             = "200-499"
+  }
 }
 
 resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.lb.arn}"
+  load_balancer_arn = aws_lb.lb.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn   = aws_acm_certificate_validation.cert.certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.lb_target_group.arn}"
+    target_group_arn = aws_lb_target_group.lb_target_group.arn
   }
 }
 
 resource "aws_lb_listener" "front_end2" {
-  load_balancer_arn = "${aws_lb.lb.arn}"
-  port              = "${var.webhook_port}"
+  load_balancer_arn = aws_lb.lb.arn
+  port              = var.webhook_port
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn   = aws_acm_certificate_validation.cert.certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.lb_target_group2.arn}"
+    target_group_arn = aws_lb_target_group.lb_target_group2.arn
   }
 }
 
 resource "aws_route53_record" "telegraf" {
-  zone_id = "${data.aws_route53_zone.relops_mozops_net.zone_id}"
+  zone_id = data.aws_route53_zone.relops_mozops_net.zone_id
   name    = "telegraf.relops.mozops.net"
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.lb.dns_name}"
-    zone_id                = "${aws_lb.lb.zone_id}"
+    name                   = aws_lb.lb.dns_name
+    zone_id                = aws_lb.lb.zone_id
     evaluate_target_health = true
   }
 }

--- a/terraform/telegraf/terraform.tfvars
+++ b/terraform/telegraf/terraform.tfvars
@@ -1,25 +1,23 @@
 tag_project_name = "telegraf"
 
-app_count = 1
-
-app_image = "961225894672.dkr.ecr.us-west-2.amazonaws.com/telegraf:latest"
-
-fargate_cpu = 4096
-
-fargate_memory = 8192
-
-app_port = 8086
-
+relay_image = "961225894672.dkr.ecr.us-west-2.amazonaws.com/telegraf:1.6"
+relay_port = 8086
 webhook_port = 1619
 
-influxdb_url = "http://34.214.39.141:8086"
+relay_count = 2
+relay_cpu = 512
+relay_memory = 1024
 
-influxdb_db = "relops"
+collection_image = "961225894672.dkr.ecr.us-west-2.amazonaws.com/telegraf:1.6"
 
+collection_count = 1
+collection_cpu = 4096
+collection_memory = 8192
+
+influxdb_url = "https://hilldale-b40313e5.influxcloud.net:8086"
+influxdb_db = "relops_workers"
 influxdb_user = "relops_wo"
 
-interval = "150s"
-
-medium_interval = "300s"
-
-long_interval = "600s"
+interval = "300s"
+medium_interval = "600s"
+long_interval = "1200s"

--- a/terraform/telegraf/vars.tf
+++ b/terraform/telegraf/vars.tf
@@ -1,26 +1,16 @@
-variable "app_count" {
-  description = "Number of application instances"
-}
+variable "relay_image" {}
+variable "relay_port" {}
+variable "webhook_port" {}
 
-variable "app_image" {
-  description = "Docker Hub slug"
-}
+variable "relay_count" {}
+variable "relay_cpu" {}
+variable "relay_memory" {}
 
-variable "fargate_cpu" {
-  description = "Maximum number of instances in the cluster"
-}
+variable "collection_image" {}
+variable "collection_count" {}
 
-variable "fargate_memory" {
-  description = "Minimum number of instances in the cluster"
-}
-
-variable "app_port" {
-  description = "Port number of application"
-}
-
-variable "webhook_port" {
-  description = "Port number of application webhook handler"
-}
+variable "collection_cpu" {}
+variable "collection_memory" {}
 
 variable "influxdb_url" {
   description = "InfluxDB host url"


### PR DESCRIPTION
The current telegraf cluster in ECS has this config, separate services for:
**telegraf** relay (influx and webhooks) to influx
**telegraf_workers** checking worker states
**telegraf_queues** checking queue levels
**telegraf_vcs** checking treestatus, m-c commits, releases (chrome, ff)

We moved to this when the requests to the TC api's began timing-out and coming back more slowly in July. This reduces the number of api calls from 4 duplicate tasks hitting all of these, on different offsets, and I increased the timeouts in the same changes. We get fewer datapoints, but we reduced traffic to the api and are more likely to get _some_ data with the long timeouts.